### PR TITLE
Update gems for integration tests

### DIFF
--- a/integration/testdata/6.0/Gemfile.lock
+++ b/integration/testdata/6.0/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.4.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
mimemagic 0.3.5, used in integration tests, was marked on rubygems.org as `yanked`. Updated to latest version.